### PR TITLE
The numbers are not converted to hyphens.

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ var transformPattern *regexp.Regexp
 var Version = "dev"
 
 func init() {
-	transformPattern = regexp.MustCompile("[^A-Z_]")
+	transformPattern = regexp.MustCompile("[^A-Z0-9_]")
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -16,6 +16,7 @@ func TestParamToEnv(t *testing.T) {
 		"/a/b/five five":        "FIVE_FIVE",
 		"/a/b/Six!@#$%^&*()siX": "SIX__________SIX",
 		"/a/b/c/d/seven":        "C_D_SEVEN",
+		"/a/b/eight8":           "EIGHT8",
 	} {
 		assert.Equal(t, expected, paramToEnv(name, "/a/b"))
 	}


### PR DESCRIPTION
This corresponds to being converted to a hyphen when trying to use key like `AWS_S3`.

ref. #5 