### PR TITLE
Add option to force setting the env

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	pathEnv = "PARAMETER_STORE_EXEC_PATH"
+	pathEnv      = "PARAMETER_STORE_EXEC_PATH"
+	overwriteEnv = "PARAMETER_STORE_EXEC_OVERWRITE"
 )
 
 var transformPattern *regexp.Regexp
@@ -58,7 +59,7 @@ func main() {
 		}
 		for name, v := range params {
 			envKey := paramToEnv(name, path)
-			if _, present := os.LookupEnv(envKey); present {
+			if _, present := os.LookupEnv(envKey); present && os.Getenv(overwriteEnv) != "true" {
 				log.Printf("%s => %s already set", name, envKey)
 			} else {
 				environ = append(environ, envKey+"="+v)


### PR DESCRIPTION
I'd like to be able to force setting the env var using values from the parameter store. Sometimes dummy values can be set in our images and I'd like the option to be able to force setting the override by setting an environment variable to ensure this happens.