### PR TITLE
go.mod for dependencies: aws-sdk-go & pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/cultureamp/parameter-store-exec
+
+go 1.13
+
+require (
+	github.com/aws/aws-sdk-go v1.26.1
+	github.com/pkg/errors v0.8.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/aws/aws-sdk-go v1.26.1 h1:JGQggXhOiNJIqsmbYUl3cYtJZUffeOWlHtxfzGK7WPI=
+github.com/aws/aws-sdk-go v1.26.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
Initialise this as a Go module, tracking the `github.com/aws/aws-sdk-go` and `github.com/pkg/errors` dependencies. This makes it easier to install with a simple `go get github.com/cultureamp/parameter-store-exec` on modern Go.

(Eventually the `github.com/pkg/errors` dependency should be replaced with the `fmt.Errorf("... %w", err)` stuff that landed in Go 1.13)